### PR TITLE
Add safe write in uploadPromise catch

### DIFF
--- a/goat.test.ts
+++ b/goat.test.ts
@@ -264,6 +264,7 @@ describe("unit: streaming RPCs", () => {
 
             // Check for any callers of the unhandledRejection mock caught during the test,
             // and assert that they were not called with a defined error.
+            // This way, we print the error in the test output.
             const mockCallArgs = unhandledRejectionFn.mock.lastCall;
             if (mockCallArgs) {
                 const unhandledRejectionError = mockCallArgs[0];

--- a/goat.test.ts
+++ b/goat.test.ts
@@ -247,6 +247,23 @@ describe("unit: streaming RPCs", () => {
 
     beforeEach(() => {
         vi.useFakeTimers();
+
+        // Listen to unhandled rejections during tests (e.g. uncaught Promise exceptions).
+        // Note, to fail the test, we assert a mock function not to be called,
+        // instead of asserting directly in the event listener, to be in the test context.
+        const unhandledRejectionFn = vi.fn();
+        const p = process.addListener("unhandledRejection", unhandledRejectionFn);
+
+        // Remove event listener and expect no unhandled rejections
+        return () => {
+            p.removeListener("unhandledRejection", unhandledRejectionFn);
+
+            // Expect any unhandled rejections do not have a defined reason
+            const mockCallArgs = unhandledRejectionFn.mock.lastCall;
+            if (mockCallArgs) {
+                expect(mockCallArgs[0]).not.toBeDefined();
+            }
+        };
     });
     afterEach(() => {
         vi.runAllTimers();
@@ -680,5 +697,35 @@ describe("unit: streaming RPCs", () => {
 
         expect(lastRpc.body).not.toBeDefined();
         expect(lastRpc.reset).toBeDefined();
+    });
+
+    // See https://github.com/avos-io/goat-es/issues/13
+    it("handles exception when sending trailer after cleanup", async () => {
+        const mock = new MockClientStreamResponder();
+        mock.mockOnEnd(() => {
+            throw new Error("test trailer error");
+        });
+
+        const transport = new GoatTransport(mock);
+        const ts = createPromiseClient(TestService, transport);
+        const signalController: AbortController = new AbortController();
+
+        // Start the streaming RPC and abort before first message
+        const ret = await ts.bidiStream(
+            (async function* () {
+                signalController.abort(new Error("Test abort"));
+                yield new Msg({ value: 99 });
+            })(),
+            { signal: signalController.signal },
+        );
+
+        await expect(async () => {
+            for await (const msg of ret) {
+                expect(msg.value).toBe(99);
+            }
+        }).rejects.toThrow("[unknown] Test abort");
+
+        // Run any outstanding work in upload loop
+        await vi.runAllTimersAsync();
     });
 });

--- a/goat.ts
+++ b/goat.ts
@@ -322,7 +322,7 @@ export class GoatTransport implements Transport {
                 resolve();
             });
             uploadPromise.catch(err => {
-                outputIterable.write(new Error(`upload error: ${err}`));
+                outputIterable.write(new Error(`upload error: ${err}`)).catch(() => {});
             });
 
             return {


### PR DESCRIPTION
This PR contains the following changes:
- Add `catch` around the write to the `outputIterable` in the `uploadPromise` `catch` block. This was causing an unhandled error in the Promise if the `outputIterable` had been closed before reaching this `catch` block (e.g. an error sending the trailer after the stream has been aborted).
- Add a unit test to cover this case. I had to do some hacky code to listen to unhandled errors (`unhandledRejection`), as the write error comes from inside a `Promise`, and doesn't get caught in the main test context. Furthermore, I couldn't just `expect.fail("Should not have unhandledRejection")` in the event listener directly, as this was not in the test context and did not fail the test. Overall, I decided to call a mock function in the `unhandledRejection` event listener, and then expect this function not to be called at the end of the test. Please let me know your thoughts on this method :)

The tests fail without the new `catch` block, and pass with it

Closes #13 