### PR TITLE
Convince tsc that there are enough string values

### DIFF
--- a/goat.ts
+++ b/goat.ts
@@ -372,7 +372,7 @@ function rpcHeadersToHeaders(reqHeader: KeyValue[] | undefined): Headers {
         return new Headers([]);
     }
     return new Headers(reqHeader.map(kv => {
-        return [kv.key, kv.value];
+        return [kv.key, kv.value] satisfies [string, string];
     }));
 }
 


### PR DESCRIPTION
`string[]` (the default inference for this var) does not satisfy `[string, string]`, as the former may contain only a single string.